### PR TITLE
fix: Update GitHub Container Registry authentication to use repositor…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # Backend metadata (tags/labels)
@@ -133,7 +133,7 @@ jobs:
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest
-    if: always() && (needs.build-and-push.result == 'success' || github.event.inputs.skip_build == 'true') && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/MVP') || github.event.inputs.deploy == 'true')
+    if: always() && (needs.build-and-push.result == 'success' || github.event.inputs.skip_build == 'true') && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/MVP') || startsWith(github.ref, 'refs/heads/dev') || github.event.inputs.deploy == 'true')
     # Use GitHub Environment for secrets and protection rules
     environment: ${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'production' || 'development') }}
     steps:


### PR DESCRIPTION
…y owner - commit message generated by copilot
This pull request makes minor but important adjustments to the GitHub Actions workflow configuration to improve authentication and deployment flexibility.

Workflow authentication and deployment updates:

* Changed the Docker login action to use `github.repository_owner` instead of `github.actor` for the username, ensuring correct permissions when pushing to the GitHub Container Registry.
* Updated the deploy job condition to allow deployments from branches starting with `dev` in addition to `main` and `MVP`, increasing deployment flexibility for development branches.