### PR TITLE
Fix for Empty except

### DIFF
--- a/src/service/auth_service.py
+++ b/src/service/auth_service.py
@@ -42,7 +42,10 @@ def register():
             try:
                 self_member = member_manager.get_or_create_self_member(user.id)
                 member_manager.update_member(self_member, height=data.get("height"))
-            except Exception:
+            except Exception as e:
+                # Height update failure is non-critical; ignore error so user registration proceeds.
+                import logging
+                logging.warning(f"Failed to update member height during registration: {e}")
                 pass
     except ValueError as e:
         if str(e) == "EMAIL_EXISTS":


### PR DESCRIPTION
To fix this, add an explanatory comment to the except block describing why failures in height updating are deliberately ignored. Ideally, add logging so such errors are recorded for debugging/monitoring, rather than fully discarding them. Only update the relevant except block at line 45 in `src/service/auth_service.py`. You may use the standard Python `logging` module, which is universally available and does not require external dependencies.

**What is needed:**  
- Add a comment above the `pass` in the except block, explaining that height update errors are deliberately ignored so as not to block user registration.
- Optionally, log the exception using Python's `logging` module for traceability.
- If logging is added, import the `logging` module at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._